### PR TITLE
change package name to correct name ceph-radosgw

### DIFF
--- a/ceph_deploy/hosts/suse/uninstall.py
+++ b/ceph_deploy/hosts/suse/uninstall.py
@@ -7,7 +7,7 @@ def uninstall(conn, purge=False):
         'libcephfs1',
         'librados2',
         'librbd1',
-        'radosgw',
+        'ceph-radosgw',
         ]
     cmd = [
         'zypper',


### PR DESCRIPTION
rename rpm radosgw to ceph-radosgw

Signed-off-by: Owen Synge osynge@suse.com
