### PR TITLE
Allow alternative cluster names with systemd

### DIFF
--- a/ceph_deploy/hosts/suse/mon/create.py
+++ b/ceph_deploy/hosts/suse/mon/create.py
@@ -4,6 +4,7 @@ from ceph_deploy.lib import remoto
 
 def create(distro, args, monitor_keyring):
     hostname = distro.conn.remote_module.shortname()
+    systemd_defaults_clustername(distro.conn, args.cluster)
     common.mon_create(distro, args, monitor_keyring, hostname)
 
     remoto.process.run(

--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -382,6 +382,8 @@ def activate(args, cfg):
         time.sleep(5)
         catch_osd_errors(distro.conn, distro.conn.logger, args)
 
+        system.systemd_defaults_clustername(distro.conn, args.cluster)
+
         if distro.is_el:
             system.enable_service(distro.conn)
 


### PR DESCRIPTION
By modifying the content of:

```
/etc/sysconfig/ceph
```

We can set the cluster name of ceph. This is done via

```
systemd_defaults_clustername
```

This code only executes on systemd systems.

Signed-off-by: Owen Synge osynge@suse.com
