### PR TITLE
abstract package cache refresh.

### DIFF
--- a/ceph_deploy/hosts/centos/pkg.py
+++ b/ceph_deploy/hosts/centos/pkg.py
@@ -13,3 +13,9 @@ def remove(distro, packages):
         distro.conn,
         packages
     )
+
+def update(distro):
+    return pkg_managers.yum_clean(
+        distro.conn,
+        "expire-cache"
+    )

--- a/ceph_deploy/hosts/debian/pkg.py
+++ b/ceph_deploy/hosts/debian/pkg.py
@@ -13,3 +13,8 @@ def remove(distro, packages):
         distro.conn,
         packages
     )
+
+def update(distro):
+    return pkg_managers.apt_update(
+        distro.conn
+    )

--- a/ceph_deploy/hosts/rhel/pkg.py
+++ b/ceph_deploy/hosts/rhel/pkg.py
@@ -13,3 +13,9 @@ def remove(distro, packages):
         distro.conn,
         packages
     )
+
+def update(distro):
+    return pkg_managers.yum_clean(
+        distro.conn,
+        "expire-cache"
+    )

--- a/ceph_deploy/hosts/suse/pkg.py
+++ b/ceph_deploy/hosts/suse/pkg.py
@@ -13,3 +13,8 @@ def remove(distro, packages):
         distro.conn,
         packages
     )
+
+def update(distro):
+    return pkg_managers.zypper_update(
+        distro.conn
+    )

--- a/ceph_deploy/util/pkg_managers.py
+++ b/ceph_deploy/util/pkg_managers.py
@@ -164,3 +164,14 @@ def zypper_remove(conn, packages, *a, **kw):
         *a,
         **kw
     )
+
+def zypper_update(conn):
+    cmd = [
+        'zypper',
+        '--non-interactive',
+        'refresh',
+        ]
+    return remoto.process.run(
+        conn,
+        cmd,
+    )


### PR DESCRIPTION
Zypper, apt, yum  have a command to just update the package cache.
When packages that are expected to be installed and are not available it
is reasonably for ceph to do this before presenting an error, a second use
case is when the the repositories are modified.

Signed-off-by: Owen Synge osynge@suse.com
